### PR TITLE
feat: add assignee and reporter details to task response

### DIFF
--- a/app/models/task.py
+++ b/app/models/task.py
@@ -5,6 +5,7 @@ from sqlalchemy import String, Text, ForeignKey, DateTime, Date, Float, Integer,
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 from app.database import Base
+from sqlalchemy.orm import relationship
 
 
 class Task(Base):
@@ -57,3 +58,5 @@ class Task(Base):
     deleted_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    assignee = relationship("User", foreign_keys=[assignee_id], lazy="select")
+    reporter = relationship("User", foreign_keys=[reporter_id], lazy="select")

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -37,6 +37,13 @@ class TaskMoveRequest(BaseModel):
     position: float
 
 
+class UserBrief(BaseModel):
+    id: uuid.UUID
+    username: str
+    full_name: str
+    avatar_url: str | None = None
+    model_config = {"from_attributes": True}
+
 class TaskResponse(BaseModel):
     id: uuid.UUID
     project_id: uuid.UUID
@@ -48,7 +55,9 @@ class TaskResponse(BaseModel):
     priority: str
     task_type: str
     assignee_id: uuid.UUID | None
+    assignee: UserBrief | None = None
     reporter_id: uuid.UUID
+    reporter: UserBrief | None = None
     due_date: datetime | None
     start_date: date | None
     estimated_hours: float | None
@@ -59,5 +68,4 @@ class TaskResponse(BaseModel):
     labels: list[str]
     created_at: datetime
     updated_at: datetime
-
     model_config = {"from_attributes": True}

--- a/app/services/helpers.py
+++ b/app/services/helpers.py
@@ -2,6 +2,7 @@ import uuid
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 from app.models.project_member import ProjectMember
 from app.models.task import Task
 from app.models.activity_log import ActivityLog
@@ -34,7 +35,9 @@ async def is_project_manager(db: AsyncSession, project_id: uuid.UUID, user_id: u
 async def get_task_or_404(db: AsyncSession, project_id: uuid.UUID, task_id: uuid.UUID) -> Task:
     """Task yoksa veya silinmişse 404 fırlatır."""
     result = await db.execute(
-        select(Task).where(
+        select(Task)
+        .options(selectinload(Task.assignee), selectinload(Task.reporter))
+        .where(
             Task.id == task_id,
             Task.project_id == project_id,
             Task.deleted_at.is_(None),

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
 from app.models.task import Task
+from sqlalchemy.orm import selectinload
 from app.schemas.task import TaskCreate, TaskUpdate, TaskMoveRequest
 from app.services.helpers import require_project_member, get_task_or_404
 
@@ -58,10 +59,12 @@ async def create_task(db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID
 async def get_tasks(db: AsyncSession, project_id: uuid.UUID, user_id: uuid.UUID, status: str | None = None, assignee_id: uuid.UUID | None = None, label: str | None = None) -> list[Task]:
     await require_project_member(db, project_id, user_id)
 
-    query = select(Task).where(
+    query = (select(Task)
+    .options(selectinload(Task.assignee), selectinload(Task.reporter))
+    .where(
         Task.project_id == project_id,
         Task.deleted_at.is_(None),
-    )
+    ))
     if status:
         query = query.where(Task.status == status)
     if assignee_id:


### PR DESCRIPTION
<details open>
<summary><strong>🇹🇷 Türkçe</strong></summary>
<br>

## 🎯 İlgili Görev (Task)

Task Ticket Number 

## 📝 Açıklama

Task response yapısı geliştirilerek, görev atanan kullanıcı (**assignee**) ve görevi oluşturan kullanıcı (**reporter**) bilgileri detaylı şekilde dönecek hale getirildi.

* Task response içerisine **assignee** ve **reporter** için nested user objeleri eklendi
* Bu alanlar için **UserSummary (UserBrief)** schema’sı kullanıldı
* Task service katmanında ilgili kullanıcı bilgileri response’a dahil edildi
* Helper fonksiyonlar güncellenerek kullanıcı verilerinin map edilmesi sağlandı

Bu değişiklik ile frontend tarafında ek kullanıcı isteği yapılmadan gerekli bilgiler tek response içinde sağlanmaktadır.

## ✅ Kontrol Listesi

* [ ] İlgili "Task Numarası" yukarıya eklendi.
* [ ] Yaptığım değişiklikler için dokümantasyon güncellendi (gerekliyse).
* [x] Commit mesajları `CONTRIBUTING.md` dosyasındaki standartlara uygun.

</details>

---

<details>
<summary><strong>🇬🇧 English</strong></summary>
<br>

## 🎯 Related Task

Task Ticket Number

## 📝 Description

Task response structure has been enhanced to include detailed information about the **assignee** and **reporter** users.

* Added nested **assignee** and **reporter** user objects to task response
* Introduced **UserSummary (UserBrief)** schema for user representation
* Updated task service layer to include user details in the response
* Updated helper functions to properly map user data

This improvement allows the frontend to access necessary user details in a single response without additional API calls.

## ✅ Checklist

* [ ] Related "Task Number" is included above.
* [ ] Documentation has been updated for my changes (if applicable).
* [x] Commit messages follow the standards in `CONTRIBUTING.md`.

</details>
