### PR TITLE
feat(org): add members listing, profile endpoints and services

### DIFF
--- a/app/models/organization_members.py
+++ b/app/models/organization_members.py
@@ -4,7 +4,7 @@ from sqlalchemy import String, ForeignKey, DateTime, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 from app.database import Base
-
+from sqlalchemy.orm import relationship
 
 class OrganizationMember(Base):
     __tablename__ = "organization_members"
@@ -29,6 +29,8 @@ class OrganizationMember(Base):
         DateTime(timezone=True), nullable=True
     )
     status: Mapped[str] = mapped_column(String(20), default="pending")
+
+    user = relationship("User", foreign_keys=[user_id], lazy="raise")
 
     __table_args__ = (
         UniqueConstraint("organization_id", "user_id", name="uq_org_member"),

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -58,5 +58,5 @@ class Task(Base):
     deleted_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
-    assignee = relationship("User", foreign_keys=[assignee_id], lazy="select")
-    reporter = relationship("User", foreign_keys=[reporter_id], lazy="select")
+    assignee = relationship("User", foreign_keys=[assignee_id], lazy="raise")
+    reporter = relationship("User", foreign_keys=[reporter_id], lazy="raise")

--- a/app/routers/organizations.py
+++ b/app/routers/organizations.py
@@ -1,10 +1,11 @@
 import uuid
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, status, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_db, get_current_user
 from app.models.user import User
-from app.schemas.organization import OrganizationCreate, OrganizationUpdate, OrganizationResponse, MemberInvite, MemberResponse
+from app.schemas.organization import OrganizationCreate, OrganizationUpdate, OrganizationResponse, MemberInvite, MemberResponse, PaginatedMembers, MemberDetailResponse
 from app.services import organization_service
+from app.services import member_service
 
 router = APIRouter(prefix="/api/v1/organizations", tags=["organizations"])
 
@@ -48,13 +49,29 @@ async def delete_organization(
     await organization_service.delete_organization(db, org_id, current_user)
 
 
-@router.get("/{org_id}/members", response_model=list[MemberResponse])
+@router.get("/{org_id}/members", response_model=PaginatedMembers)
 async def list_members(
     org_id: uuid.UUID,
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=20, ge=1, le=100),
+    search: str | None = Query(default=None),
+    role: str | None = Query(default=None),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db)):
-    return await organization_service.get_members(db, org_id, current_user)
+    return await member_service.list_members(
+        db, org_id, current_user.id, page, limit, search, role
+    )
 
+
+@router.get("/{org_id}/members/{user_id}", response_model=MemberDetailResponse)
+async def get_member_detail(
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db)):
+    return await member_service.get_member_detail(
+        db, org_id, user_id, current_user.id
+    )
 
 @router.post("/{org_id}/members", response_model=MemberResponse, status_code=201)
 async def invite_member(

--- a/app/schemas/organization.py
+++ b/app/schemas/organization.py
@@ -34,7 +34,7 @@ class OrganizationResponse(BaseModel):
     plan: str
     org_type: str | None  # setup wizard'dan geliyor
     invite_method: str  # email | invite_link | domain_allowlist
-    is_member: bool = False  # kullanıcının bu org'a üye olup olmadığı
+    is_member: bool = False
     created_at: datetime
     model_config = {"from_attributes": True}
 
@@ -57,4 +57,79 @@ class MemberResponse(BaseModel):
     role: str
     status: str
     joined_at: datetime | None
+    model_config = {"from_attributes": True}
+
+
+# ── Üye listeleme
+
+class MemberUserInfo(BaseModel):
+    """Üye listesinde kullanıcı bilgileri."""
+    id: uuid.UUID
+    username: str
+    full_name: str
+    avatar_url: str | None = None
+    email: str
+    model_config = {"from_attributes": True}
+
+
+class MemberListItem(BaseModel):
+    """Üye listesi için tek satır."""
+    id: uuid.UUID  # organization_members.id
+    user_id: uuid.UUID
+    role: str  # owner | member
+    status: str
+    joined_at: datetime | None
+    user: MemberUserInfo
+    model_config = {"from_attributes": True}
+
+
+class PaginatedMembers(BaseModel):
+    items: list[MemberListItem]
+    total: int
+    page: int
+    limit: int
+    has_next: bool
+
+
+# ── Üye profil detayı
+
+class MemberProjectInfo(BaseModel):
+    """Üyenin katıldığı proje özeti."""
+    id: uuid.UUID
+    name: str
+    key: str
+    status: str
+    role: str  # projedeki rolü
+    model_config = {"from_attributes": True}
+
+
+class ActivityFeedItem(BaseModel):
+    """Son aktivite özeti."""
+    action: str
+    entity_type: str
+    created_at: datetime
+    model_config = {"from_attributes": True}
+
+
+class MemberStats(BaseModel):
+    """Üye istatistikleri."""
+    total_projects: int
+    total_tasks: int
+    completed_tasks: int
+
+
+class MemberDetailResponse(BaseModel):
+    """Üye profil detayı."""
+    id: uuid.UUID
+    username: str
+    full_name: str
+    avatar_url: str | None = None
+    email: str
+    timezone: str
+    is_active: bool
+    joined_at: datetime | None  # org'a katılım tarihi
+    org_role: str  # org'daki rolü: owner | member
+    stats: MemberStats
+    projects: list[MemberProjectInfo]
+    recent_activity: list[ActivityFeedItem]
     model_config = {"from_attributes": True}

--- a/app/services/helpers.py
+++ b/app/services/helpers.py
@@ -33,7 +33,10 @@ async def is_project_manager(db: AsyncSession, project_id: uuid.UUID, user_id: u
 
 
 async def get_task_or_404(db: AsyncSession, project_id: uuid.UUID, task_id: uuid.UUID) -> Task:
-    """Task yoksa veya silinmişse 404 fırlatır."""
+    """Task yoksa veya silinmişse 404 fırlatır.
+    assignee ve reporter selectinload ile yüklenir —
+    lazy="raise" olduğu için explicit yükleme zorunlu.
+    """
     result = await db.execute(
         select(Task)
         .options(selectinload(Task.assignee), selectinload(Task.reporter))

--- a/app/services/member_service.py
+++ b/app/services/member_service.py
@@ -1,0 +1,210 @@
+import uuid
+from fastapi import HTTPException
+from sqlalchemy import select, func, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from app.models.organization_members import OrganizationMember
+from app.models.project_member import ProjectMember
+from app.models.project import Project
+from app.models.task import Task
+from app.models.activity_log import ActivityLog
+from app.models.user import User
+from app.schemas.organization import (
+    PaginatedMembers,
+    MemberListItem,
+    MemberUserInfo,
+    MemberDetailResponse,
+    MemberStats,
+    MemberProjectInfo,
+    ActivityFeedItem,
+)
+from app.services.helpers import require_project_member
+from app.services.organization_service import _require_member
+
+
+async def list_members(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    current_user_id: uuid.UUID,
+    page: int,
+    limit: int,
+    search: str | None,
+    role: str | None,
+) -> PaginatedMembers:
+    # Sadece org üyeleri erişebilir
+    await _require_member(db, org_id, current_user_id)
+
+    offset = (page - 1) * limit
+
+    # Base query — User join ile
+    base_query = (
+        select(OrganizationMember)
+        .join(User, User.id == OrganizationMember.user_id)
+        .where(
+            OrganizationMember.organization_id == org_id,
+            OrganizationMember.status == "active",
+            User.deleted_at.is_(None),
+        )
+        .options(selectinload(OrganizationMember.user))
+    )
+
+    # Arama filtresi
+    if search:
+        base_query = base_query.where(
+            or_(
+                User.username.ilike(f"%{search}%"),
+                User.email.ilike(f"%{search}%"),
+                User.full_name.ilike(f"%{search}%"),
+            )
+        )
+
+    # Rol filtresi
+    if role:
+        if role not in ["owner", "member"]:
+            raise HTTPException(status_code=422, detail="Geçerli roller: owner, member")
+        base_query = base_query.where(OrganizationMember.role == role)
+
+    # Toplam sayı
+    count_query = select(func.count()).select_from(base_query.subquery())
+    total = (await db.execute(count_query)).scalar_one()
+
+    # Sayfalı sonuç
+    result = await db.execute(
+        base_query.order_by(OrganizationMember.joined_at.asc()).offset(offset).limit(limit)
+    )
+    members = result.scalars().all()
+
+    items = [
+        MemberListItem(
+            id=m.id,
+            user_id=m.user_id,
+            role=m.role,
+            status=m.status,
+            joined_at=m.joined_at,
+            user=MemberUserInfo(
+                id=m.user.id,
+                username=m.user.username,
+                full_name=m.user.full_name,
+                avatar_url=m.user.avatar_url,
+                email=m.user.email,
+            ),
+        )
+        for m in members
+    ]
+
+    return PaginatedMembers(
+        items=items,
+        total=total,
+        page=page,
+        limit=limit,
+        has_next=(offset + len(items)) < total,
+    )
+
+
+async def get_member_detail(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    target_user_id: uuid.UUID,
+    current_user_id: uuid.UUID,
+) -> MemberDetailResponse:
+    # Sadece org üyeleri erişebilir
+    await _require_member(db, org_id, current_user_id)
+
+    # Hedef kullanıcının org üyeliğini bul
+    result = await db.execute(
+        select(OrganizationMember)
+        .join(User, User.id == OrganizationMember.user_id)
+        .where(
+            OrganizationMember.organization_id == org_id,
+            OrganizationMember.user_id == target_user_id,
+            OrganizationMember.status == "active",
+            User.deleted_at.is_(None),
+        )
+        .options(selectinload(OrganizationMember.user))
+    )
+    org_member = result.scalar_one_or_none()
+    if not org_member:
+        raise HTTPException(status_code=404, detail="Üye bulunamadı")
+
+    user = org_member.user
+
+    # Katıldığı projeler (bu org'daki)
+    proj_result = await db.execute(
+        select(Project, ProjectMember)
+        .join(ProjectMember, ProjectMember.project_id == Project.id)
+        .where(
+            Project.organization_id == org_id,
+            ProjectMember.user_id == target_user_id,
+            Project.deleted_at.is_(None),
+        )
+    )
+    project_rows = proj_result.all()
+    projects = [
+        MemberProjectInfo(
+            id=p.id,
+            name=p.name,
+            key=p.key,
+            status=p.status,
+            role=pm.role,
+        )
+        for p, pm in project_rows
+    ]
+
+    # İstatistikler
+    total_projects = len(projects)
+
+    total_tasks_result = await db.execute(
+        select(func.count()).where(
+            Task.assignee_id == target_user_id,
+            Task.deleted_at.is_(None),
+        )
+    )
+    total_tasks = total_tasks_result.scalar_one()
+
+    completed_tasks_result = await db.execute(
+        select(func.count()).where(
+            Task.assignee_id == target_user_id,
+            Task.status == "done",
+            Task.deleted_at.is_(None),
+        )
+    )
+    completed_tasks = completed_tasks_result.scalar_one()
+
+    # Son aktivite (en son 10)
+    activity_result = await db.execute(
+        select(ActivityLog)
+        .where(
+            ActivityLog.actor_id == target_user_id,
+            ActivityLog.organization_id == org_id,
+        )
+        .order_by(ActivityLog.created_at.desc())
+        .limit(10)
+    )
+    activities = activity_result.scalars().all()
+    recent_activity = [
+        ActivityFeedItem(
+            action=a.action,
+            entity_type=a.entity_type,
+            created_at=a.created_at,
+        )
+        for a in activities
+    ]
+
+    return MemberDetailResponse(
+        id=user.id,
+        username=user.username,
+        full_name=user.full_name,
+        avatar_url=user.avatar_url,
+        email=user.email,
+        timezone=user.timezone,
+        is_active=user.is_active,
+        joined_at=org_member.joined_at,
+        org_role=org_member.role,
+        stats=MemberStats(
+            total_projects=total_projects,
+            total_tasks=total_tasks,
+            completed_tasks=completed_tasks,
+        ),
+        projects=projects,
+        recent_activity=recent_activity,
+    )

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -52,8 +52,7 @@ async def create_task(db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID
     )
     db.add(task)
     await db.commit()
-    await db.refresh(task)
-    return task
+    return await get_task_or_404(db, project_id, task.id)
 
 
 async def get_tasks(db: AsyncSession, project_id: uuid.UUID, user_id: uuid.UUID, status: str | None = None, assignee_id: uuid.UUID | None = None, label: str | None = None) -> list[Task]:
@@ -95,8 +94,7 @@ async def update_task(db: AsyncSession, project_id: uuid.UUID, task_id: uuid.UUI
         task.completed_at = None
 
     await db.commit()
-    await db.refresh(task)
-    return task
+    return await get_task_or_404(db, project_id, task_id)
 
 
 async def move_task(db: AsyncSession, project_id: uuid.UUID, task_id: uuid.UUID, data: TaskMoveRequest, user_id: uuid.UUID) -> Task:
@@ -115,8 +113,7 @@ async def move_task(db: AsyncSession, project_id: uuid.UUID, task_id: uuid.UUID,
     await _rebalance_if_needed(db, project_id, data.status)
 
     await db.commit()
-    await db.refresh(task)
-    return task
+    return await get_task_or_404(db, project_id, task_id)
 
 
 async def delete_task(db: AsyncSession, project_id: uuid.UUID, task_id: uuid.UUID, user_id: uuid.UUID):

--- a/tests/test_members.py
+++ b/tests/test_members.py
@@ -1,0 +1,155 @@
+import pytest
+
+
+MEMBERS_URL = "/api/v1/organizations/{org_id}/members"
+
+
+# ── Üye Listeleme
+
+@pytest.mark.asyncio
+async def test_list_members_success(auth_client, org):
+    """Org üyeleri listelenebilmeli."""
+    response = await auth_client.get(MEMBERS_URL.format(org_id=org["id"]))
+    assert response.status_code == 200
+    data = response.json()
+    assert "items" in data
+    assert "total" in data
+    assert data["total"] >= 1
+    assert any(m["role"] == "owner" for m in data["items"])
+
+
+@pytest.mark.asyncio
+async def test_list_members_unauthenticated(client, completed_setup, org):
+    """Giriş yapmamış kullanıcı erişemez."""
+    response = await client.get(MEMBERS_URL.format(org_id=org["id"]),
+                                headers={"Authorization": "Bearer invalid_token"})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_members_pagination(auth_client, org):
+    """Sayfalama doğru çalışmalı."""
+    response = await auth_client.get(
+        MEMBERS_URL.format(org_id=org["id"]),
+        params={"page": 1, "limit": 10}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["page"] == 1
+    assert data["limit"] == 10
+    assert "has_next" in data
+
+
+@pytest.mark.asyncio
+async def test_list_members_search(auth_client, org):
+    """Arama çalışmalı."""
+    response = await auth_client.get(
+        MEMBERS_URL.format(org_id=org["id"]),
+        params={"search": "owner"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_list_members_filter_by_role(auth_client, org):
+    """Rol filtresi çalışmalı."""
+    response = await auth_client.get(
+        MEMBERS_URL.format(org_id=org["id"]),
+        params={"role": "owner"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert all(m["role"] == "owner" for m in data["items"])
+
+
+@pytest.mark.asyncio
+async def test_list_members_invalid_role(auth_client, org):
+    """Geçersiz rol filtresi 422 döndürmeli."""
+    response = await auth_client.get(
+        MEMBERS_URL.format(org_id=org["id"]),
+        params={"role": "invalid_role"}
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_list_members_user_info_present(auth_client, org):
+    """Her üyede kullanıcı bilgileri bulunmalı."""
+    response = await auth_client.get(MEMBERS_URL.format(org_id=org["id"]))
+    data = response.json()
+    for member in data["items"]:
+        assert "user" in member
+        assert "username" in member["user"]
+        assert "email" in member["user"]
+        assert "full_name" in member["user"]
+        assert "password_hash" not in member["user"]
+
+
+# ── Üye Profil Detayı
+
+@pytest.mark.asyncio
+async def test_get_member_detail_success(auth_client, org):
+    """Üye profil detayı dönmeli."""
+    me = (await auth_client.get("/api/v1/auth/me")).json()
+    response = await auth_client.get(
+        f"/api/v1/organizations/{org['id']}/members/{me['id']}"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == me["id"]
+    assert data["username"] == me["username"]
+    assert "org_role" in data
+    assert "stats" in data
+    assert "projects" in data
+    assert "recent_activity" in data
+
+
+@pytest.mark.asyncio
+async def test_get_member_detail_stats(auth_client, org, project, task):
+    """İstatistikler doğru dönmeli."""
+    me = (await auth_client.get("/api/v1/auth/me")).json()
+    response = await auth_client.get(
+        f"/api/v1/organizations/{org['id']}/members/{me['id']}"
+    )
+    data = response.json()
+    stats = data["stats"]
+    assert "total_projects" in stats
+    assert "total_tasks" in stats
+    assert "completed_tasks" in stats
+    assert stats["total_projects"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_get_member_detail_not_found(auth_client, org):
+    """Olmayan üye 404 döndürmeli."""
+    fake_id = "00000000-0000-0000-0000-000000000000"
+    response = await auth_client.get(
+        f"/api/v1/organizations/{org['id']}/members/{fake_id}"
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_member_detail_no_sensitive_data(auth_client, org):
+    """Hassas veriler response'da bulunmamalı."""
+    me = (await auth_client.get("/api/v1/auth/me")).json()
+    response = await auth_client.get(
+        f"/api/v1/organizations/{org['id']}/members/{me['id']}"
+    )
+    data = response.json()
+    assert "password_hash" not in data
+    assert "oauth_id" not in data
+
+
+@pytest.mark.asyncio
+async def test_get_member_detail_projects(auth_client, org, project):
+    """Üyenin katıldığı projeler dönmeli."""
+    me = (await auth_client.get("/api/v1/auth/me")).json()
+    response = await auth_client.get(
+        f"/api/v1/organizations/{org['id']}/members/{me['id']}"
+    )
+    data = response.json()
+    assert len(data["projects"]) >= 1
+    assert any(p["id"] == project["id"] for p in data["projects"])

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -326,8 +326,9 @@ async def test_list_members_success(auth_client, org):
     response = await auth_client.get(f"/api/v1/organizations/{org['id']}/members")
     assert response.status_code == 200
     data = response.json()
-    assert len(data) >= 1
-    assert any(m["role"] == "owner" for m in data)
+    assert "items" in data
+    assert data["total"] >= 1
+    assert any(m["role"] == "owner" for m in data["items"])
 
 
 @pytest.mark.asyncio
@@ -363,7 +364,7 @@ async def test_remove_member_success(auth_client, client, org):
     members = (await auth_client.get(
         f"/api/v1/organizations/{org['id']}/members"
     )).json()
-    assert not any(m["user_id"] == user_id and m["status"] == "active" for m in members)
+    assert not any(m["user_id"] == user_id and m["status"] == "active" for m in members["items"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<details open>
<summary><strong>🇹🇷 Türkçe</strong></summary>
<br>

## 🎯 İlgili Görev (Task)

Task Ticket Number #29 

## 📝 Açıklama

Organization üyelerinin listelenmesi ve kullanıcı profil detaylarının geliştirilmesi için membership yönetimi ve detaylı profil endpoint’leri implement edildi.

Bu kapsamda kullanıcı listesi, filtreleme, arama ve sayfalama desteği ile birlikte genişletildi; ayrıca kullanıcı detay sayfası için proje katılımı ve istatistik verileri eklendi.

### Yapılan değişiklikler

* Organization üyeleri için listeleme endpoint’i geliştirildi:

  * Sayfalama (`page`, `limit`)
  * Arama (`username`, `email`)
  * Rol filtresi (`owner`, `member`)
  * Soft delete (`deleted_at`) filtreleme

* Kullanıcı detay endpoint’i implement edildi:

  * Kullanıcının profil bilgileri
  * Katıldığı projeler
  * Görev istatistikleri
  * Son aktivite kayıtları (activity_logs)
  * Org ve proje bazlı role bilgileri

* Response güvenliği sağlandı:

  * Hassas alanlar (password_hash vb.) exclude edildi
  * Sadece yetkili kullanıcılar erişebilir hale getirildi

* Multi-org yapı desteklendi:

  * Kullanıcıların birden fazla org’a üye olabilmesi
  * Her org’un kendi üyelerini bağımsız yönetmesi

---

## ✅ Kontrol Listesi

* [x] İlgili "Task Numarası" yukarıya eklendi.
* [ ] Yaptığım değişiklikler için dokümantasyon güncellendi (gerekliyse).
* [x] Commit mesajları `CONTRIBUTING.md` dosyasındaki standartlara uygun.

</details>

---

<details>
<summary><strong>🇬🇧 English</strong></summary>
<br>

## 🎯 Related Task

Task Ticket Number #29

## 📝 Description

Implemented organization membership management and extended user profile endpoints to support detailed member listing and profile analytics.

### Changes made

* Enhanced organization members listing endpoint:

  * Pagination (`page`, `limit`)
  * Search by `username` and `email`
  * Role filtering (`owner`, `member`)
  * Soft delete filtering (`deleted_at` excluded)

* Implemented user profile detail endpoint:

  * User profile information
  * Project participation data
  * Task statistics
  * Recent activity logs (activity_logs)
  * Organization and project role information

* Improved response security:

  * Sensitive fields (e.g. password_hash) excluded
  * Access restricted to authorized users only

* Supported multi-organization structure:

  * Users can belong to multiple organizations
  * Each organization manages its members independently

---

## ✅ Checklist

* [x] Related "Task Number" is included above.
* [ ] Documentation has been updated for my changes (if applicable).
* [x] Commit messages follow the standards in `CONTRIBUTING.md`.

</details>